### PR TITLE
Refactor BookmarkTable and Infox to handle undefined sheets gracefully

### DIFF
--- a/src/bookmarktable.ts
+++ b/src/bookmarktable.ts
@@ -13,7 +13,7 @@ export class BookmarkTable {
     // Logger.log("############### BookmarkTable constructor call SpreadSheetx() without arg");
     this.ssx = new SpreadSheetx("");
     this.ssx.openByUrl(this.url);
-    this.s_sheet = this.ssx.getSheet(this.sheetName);
+    this.s_sheet = this.ssx.getSheet(this.sheetName) ?? new SSheet(null, this.sheetName);
     // Util.log(`BookmarkTable url=${url}|sheetName=${sheetName}`)
   }
   reform(values: string[][]): string[][] {

--- a/src/infox.ts
+++ b/src/infox.ts
@@ -19,9 +19,20 @@ export class Infox {
         this.CONST_SS_ID = "1KtGdnnpj8k_bkxfYITalK193nRlVXiN0o_YiASO5KNs";
         this.sheet_name = sheet_name;
         this.ssxx = new SpreadSheetx(this.CONST_SS_ID);
-        this.ssheet = this.ssxx.getSheet(this.sheet_name);
-        this.ssheet.fetchAndSetDataRange();
-        this.values = this.ssheet.getValues();
+        this.ssheet = new SSheet(null, this.sheet_name);
+        const canGetSheet = this.sheet_name !== "" && this.ssxx.ss !== null;
+        if (canGetSheet) {
+            const ssheet = this.ssxx.getSheet(this.sheet_name);
+            if (ssheet !== undefined) {
+                this.ssheet = ssheet;
+            }
+        }
+        if (this.ssheet.sheet !== null) {
+            this.ssheet.fetchAndSetDataRange();
+            this.values = this.ssheet.getValues();
+        } else {
+            this.values = [[""]];
+        }
     }
     getValues(): string[][] {
         // Util.log(`Infox getValues() 1`)


### PR DESCRIPTION
- In BookmarkTable, updated the sheet assignment to use a fallback SSheet instance if the sheet is not found.
- In Infox, modified the sheet initialization logic to check for valid sheet names and handle cases where the sheet may not exist, ensuring that values are set to a default if the sheet is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sheet initialization reliability with enhanced fallback handling for missing or unavailable sheets.
  * Added defensive control flow to ensure graceful data loading when sheet lookup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->